### PR TITLE
Удалена лишняя переменная из проверки лицензии

### DIFF
--- a/index.php
+++ b/index.php
@@ -48,7 +48,7 @@ if (($res = $view->fetch()) !== false) {
 }
 
 
-$p=11; $g=2; $x=7; $r = ''; $s = $x;
+$p=11; $x=7; $r = ''; $s = $x;
 $bs = explode(' ', $view->config->license);
 foreach ($bs as $bl) {
     for ($i=0, $m=''; $i<strlen($bl)&&isset($bl[$i+1]); $i+=2) {

--- a/simpla/LicenseAdmin.php
+++ b/simpla/LicenseAdmin.php
@@ -22,7 +22,6 @@ class LicenseAdmin extends Simpla
         }
 
         $p=11;
-        $g=2;
         $x=7;
         $r = '';
         $s = $x;


### PR DESCRIPTION
В IndexAdmin.php уже сделано.

Эта переменная нужна только для генерации ключа, но не для его расшифровки.